### PR TITLE
Skip URL scanning during Lando startup to avoid 403 warnings

### DIFF
--- a/setup/bootstrap.php
+++ b/setup/bootstrap.php
@@ -225,8 +225,8 @@ function start_lando() {
         }
     }
     
-    // Start Lando - show all output
-    passthru('lando start', $return_code);
+    // Start Lando - show all output but skip URL scanning
+    passthru('lando start --no-scanner', $return_code);
     
     if ($return_code !== 0) {
         error_exit("Failed to start Lando. Please check the error messages above.");


### PR DESCRIPTION
  Add --no-scanner flag to lando start command to prevent unnecessary 403
  errors from appearing during initial setup when WordPress isn't installed yet.